### PR TITLE
Fix getting file paths to remove

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -158,7 +158,7 @@ func getFilePaths(path string) []string {
 	var files []string
 
 	// go through each file
-	err := filepath.WalkDir(".", func(s string, d fs.DirEntry, e error) error {
+	err := filepath.WalkDir(path, func(s string, d fs.DirEntry, e error) error {
 		if e != nil {
 			return e
 		}


### PR DESCRIPTION
Fixes #4

The current implementation checks for duplicates in the current directory, which can lead to the deletion of identical files there.