### PR TITLE
Fix deduplication stability

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	filepath "path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -145,6 +146,7 @@ func RemoveDuplicates(path string, console bool) {
 
 	// for each hash, remove all the files except the first one
 	for _, files := range hashfiles {
+		sort.Strings(files)
 		for _, fileToRemove := range files[1:] {
 			if console {
 				fmt.Printf("Removing duplicate file: %s\n", fileToRemove)


### PR DESCRIPTION
Since the `map`-s in Go are unordered, this leads to the fact that duplicates can overwrite each other with each update.
Here is an example of running one of the updates:
```
Removed files:
        detect-drone.yaml
        flywheel_takeover.yaml
        sqli.yaml
        unauthenticated-jenkin-dashboard.yaml

Added files:
        detect-drone-config.yaml
        flywheel-takeover.yaml
        sql-injection.yaml
        unaunthenticated-jenkin.yaml
```