### PR TITLE
Update the installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Community edition nuclei templates, a simple tool that allows you to organize al
 
 # Install
 ```
-GO111MODULE=on go get -u github.com/xm1k3/cent
+GO111MODULE=on go install -v github.com/xm1k3/cent@latest
 ```
 
 Or [download from releases](https://github.com/xm1k3/cent/releases)


### PR DESCRIPTION
'go get' is no longer supported outside a module. So I change installation command to "GO111MODULE=on go install -v github.com/xm1k3/cent@latest" in README.md.