### PR TITLE
delete useless repo in .cent.yaml

### DIFF
--- a/.cent.yaml
+++ b/.cent.yaml
@@ -23,7 +23,6 @@ community-templates:
   - https://github.com/daffainfo/my-nuclei-templates
   - https://github.com/esetal/nuclei-bb-templates
   - https://github.com/ethicalhackingplayground/erebus-templates
-  - https://github.com/foulenzer/foulenzer-templates
   - https://github.com/geeknik/nuclei-templates-1
   - https://github.com/geeknik/the-nuclei-templates
   - https://github.com/Harish4948/Nuclei-Templates


### PR DESCRIPTION
delete https://github.com/foulenzer/foulenzer-templates which is 404