### PR TITLE
Check function

### DIFF
--- a/.cent.yaml
+++ b/.cent.yaml
@@ -11,7 +11,6 @@ exclude-files:
 
 # Add github urls
 community-templates:
-  - https://github.com/0x727/ObserverWard_0x727
   - https://github.com/0xAwali/Virtual-Host
   - https://github.com/0xPugazh/my-nuclei-templates
   - https://github.com/0xmaximus/final_freaking_nuclei_templates

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -1,0 +1,30 @@
+name: 🎉 Release Binary
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
+      
+      - name: "Set up Go"
+        uses: actions/setup-go@v4
+        with: 
+          go-version: 1.20
+          check-latest: true
+          cache: true
+      
+      - name: "Create release on GitHub"
+        uses: goreleaser/goreleaser-action@v4
+        with: 
+          args: "release --rm-dist"
+          version: latest
+          workdir: .

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,35 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+
+  ignore:
+    - goos: darwin
+      goarch: '386'
+    - goos: windows
+      goarch: 'arm'
+    - goos: windows
+      goarch: 'arm64'
+
+  binary: '{{ .ProjectName }}'
+  main: cmd/{{ .ProjectName }}/{{ .ProjectName }}.go
+
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
+
+checksum:
+  algorithm: sha256
+  

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2023 xm1k3
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/xm1k3/cent/pkg/jobs"
+)
+
+// checkCmd represents the check command
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check if templates repo are still available",
+	Long:  `Check if templates repo are still available`,
+	Run: func(cmd *cobra.Command, args []string) {
+		removeFlag, _ := cmd.Flags().GetBool("remove")
+		err := jobs.CheckConfig(cfgFile, removeFlag)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+
+	checkCmd.Flags().BoolP("remove", "r", false, "Remove from .cent.yaml urls that are no longer accessible or are currently private")
+
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -66,3 +66,13 @@ func DownloadFile(filepath string, url string) error {
 	_, err = io.Copy(out, resp.Body)
 	return err
 }
+
+func RemoveStringFromSlice(slice []string, strToRemove string) []string {
+	result := []string{}
+	for _, str := range slice {
+		if str != strToRemove {
+			result = append(result, str)
+		}
+	}
+	return result
+}

--- a/pkg/jobs/check.go
+++ b/pkg/jobs/check.go
@@ -1,0 +1,99 @@
+package jobs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/fatih/color"
+	"github.com/xm1k3/cent/internal/utils"
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	ExcludeDirs        []string `yaml:"exclude-dirs"`
+	ExcludeFiles       []string `yaml:"exclude-files"`
+	CommunityTemplates []string `yaml:"community-templates"`
+}
+
+func CheckConfig(configPath string, removeFlag bool) error {
+	yamlFile, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	var config Config
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+
+	for _, url := range config.CommunityTemplates {
+		wg.Add(1)
+
+		go func(url string) {
+			defer wg.Done()
+
+			resp, err := http.Get(url)
+			if err != nil {
+				fmt.Printf("Error on GET request for %s: %s\n", url, err)
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode == http.StatusOK {
+				fmt.Println(color.GreenString("[SUCCESS] URL %s Status code: %d", url, resp.StatusCode))
+				return
+			} else if resp.StatusCode == http.StatusNotFound {
+				fmt.Println(color.RedString("[ERR] URL %s  Status code: %d", url, resp.StatusCode))
+				if removeFlag {
+					RemoveURLFromConfig(configPath, url)
+				}
+			} else {
+				fmt.Println(color.RedString("[ERR] URL %s  Status code: %d", url, resp.StatusCode))
+			}
+		}(url)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func RemoveURLFromConfig(configPath, url string) error {
+	yamlFile, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	var config Config
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return err
+	}
+
+	updatedConfig := Config{
+		ExcludeDirs:        config.ExcludeDirs,
+		ExcludeFiles:       config.ExcludeFiles,
+		CommunityTemplates: utils.RemoveStringFromSlice(config.CommunityTemplates, url),
+	}
+
+	updatedYAML, err := yaml.Marshal(&updatedConfig)
+	if err != nil {
+		return err
+	}
+
+	updatedYAMLString := string(updatedYAML)
+	updatedYAMLString = strings.ReplaceAll(updatedYAMLString, "  ", " ")
+
+	err = ioutil.WriteFile(configPath, []byte(updatedYAMLString), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Usage
```
cent check --help

Check if templates repo are still available

Usage:
  cent check [flags]

Flags:
  -h, --help     help for check
  -r, --remove   Remove from .cent.yaml urls that are no longer accessible or are currently private

Global Flags:
      --config string   config file (default is $HOME/.cent.yaml)
```
## Test yaml
```yaml
...
...
community-templates:
  - https://github.com/joanbono/nuclei-templates
  - https://github.com/0xPugazh/my-nuclei-templates
  - https://github.com/1in9e/my-nuclei-templates
  - https://github.com/5cr1pt/templates

```

## Command

```
cent check --config .cent.yaml -r
```

## Output

```
[ERR] URL https://github.com/joanbono/nuclei-templates  Status code: 404
[SUCCESS] URL https://github.com/0xPugazh/my-nuclei-templates Status code: 200
[SUCCESS] URL https://github.com/1in9e/my-nuclei-templates Status code: 200
[SUCCESS] URL https://github.com/5cr1pt/templates Status code: 200
```

## Updated yaml

```yaml
...
...
community-templates:
  - https://github.com/0xPugazh/my-nuclei-templates
  - https://github.com/1in9e/my-nuclei-templates
  - https://github.com/5cr1pt/templates

```