### PR TITLE
Fix bug in copying files with special characters in file path

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -92,7 +92,7 @@ func Start(_path string, keepfolders bool, console bool, threads int, defaultTim
 					if !keepfolders {
 						directory = ""
 					}
-					utils.RunCommand("cp "+path+" "+filepath.Join(_path, directory), console, defaultTimeout)
+					utils.RunCommand("cp '"+path+"' '"+filepath.Join(_path, directory)+"'", console, defaultTimeout)
 				}
 			}
 			return nil


### PR DESCRIPTION

Fix on linux/mac copy templates files with not-accessible chars


> [!NOTE]
> `cp /tmp/template 1.yml /tmp/`
> 
>  Can be dangerous, but work
> `cp '/tmp/template 1.yml' '/tmp/'`

---

> [!WARNING]
> Not works bug on Win