### PR TITLE
fix: validate worker pattern

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -23,39 +23,77 @@ var validateCmd = &cobra.Command{
 When executed, it scans a specified folder for YAML files. Each YAML file is checked for validity. 
 If a template is found to be invalid, it is deleted from the folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		maxWorkers := 1000
+
 		path, _ := cmd.Flags().GetString("path")
-
 		var wg sync.WaitGroup
-		filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
-			if err != nil {
-				log.Fatal(err)
-			}
-			if info.IsDir() {
-			} else if filepath.Ext(filePath) == ".yaml" {
-				wg.Add(1)
-				go func(filePath string) {
-					defer wg.Done()
 
-					data, err := readFile(filePath)
-					if err != nil {
-						return
-					}
+		
+		workerPool := make(chan struct{}, maxWorkers)
 
-					isValid, err := jobs.ValidateTemplate(data)
-					if err != nil {
-						fmt.Println(filePath, err)
-					}
-
-					if !isValid {
-						os.Remove(filePath)
-					}
-				}(filePath)
-			}
-			return nil
-		})
+		err := processFiles(path, &wg, workerPool)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		wg.Wait()
 	},
+}
+
+// Walk through files and process them
+func processFiles(path string, wg *sync.WaitGroup, workerPool chan struct{}) error {
+	return filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(filePath) == ".yaml" {
+			wg.Add(1)
+			processFile(filePath, wg, workerPool)
+		}
+
+		return nil
+	})
+}
+
+// Process an individual file
+func processFile(filePath string, wg *sync.WaitGroup, workerPool chan struct{}) {
+	// Acquire a worker slot from the pool
+	workerPool <- struct{}{}
+
+	go func(filePath string) {
+		defer func() {
+			wg.Done()
+			<-workerPool // Release the worker slot
+		}()
+
+		if err := validateTemplate(filePath); err != nil {
+			fmt.Println(filePath, err)
+		}
+	}(filePath)
+}
+
+// Validate a single template file
+func validateTemplate(filePath string) error {
+	data, err := readFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	isValid, err := jobs.ValidateTemplate(data)
+	if err != nil {
+		return err
+	}
+
+	if !isValid {
+		return os.Remove(filePath)
+	}
+
+	return nil
 }
 
 func readFile(filePath string) (string, error) {
@@ -69,4 +107,5 @@ func readFile(filePath string) (string, error) {
 func init() {
 	rootCmd.AddCommand(validateCmd)
 	validateCmd.Flags().StringP("path", "p", "cent-nuclei-templates", "Root path to save the templates")
+
 }


### PR DESCRIPTION
Fixed bug where worker gets created for each template, resulting in crash because it creates too much threads.

I have added worker pool pattern with max 1000 workers and refactored it into 3 funcs instead of 1.

Tested on:
- `Ubuntu 22.04.3 LTS`
- `go version go1.23.5 linux/amd64`