### PR TITLE
Speed up git cloning by adding optimisations to git.CloneOptions

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -23,6 +23,9 @@ import (
 func cloneRepo(gitPath string, console bool, index string, timestamp string) error {
 	cloneOptions := &git.CloneOptions{
 		URL: gitPath,
+		Depth: 1,
+		SingleBranch: true,
+		Tags: git.NoTags,
 	}
 
 	destDir := filepath.Join(os.TempDir(), fmt.Sprintf("cent%s/repo%s", timestamp, index))


### PR DESCRIPTION
Clone only depth 1 (not the entire git history), single branch, no tags.