### PR TITLE
Fix issues: keep-folders, local validation, timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ after installation run `cent init` to initialize cent with the configuration fil
 Flags:
       --config string   config file (default is .config/cent/.cent.yaml)
   -C, --console         Print console output
+  -k, --keep-folders    Keep templates organized in folders by repo name
   -p, --path string     Root path to save the templates (default "cent-nuclei-templates")
   -t, --threads int     Number of threads to use when cloning repositories (default 10)
 ```
@@ -84,6 +85,22 @@ cent started
 ... 
 ...
 cent finished, you can find all your nuclei-templates in cent-nuclei-templates
+```
+
+### Keep templates organized by repo
+Use the `-k` flag to keep templates in separate folders named after the source repository:
+```
+cent -p cent-nuclei-templates -k
+```
+This will create a folder structure like:
+```
+cent-nuclei-templates/
+  projectdiscovery/nuclei-templates/
+    cve-2021-1234.yaml
+    ...
+  user/repo-name/
+    custom-template.yaml
+    ...
 ```
 
 ## Summary Command

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Flags:
   -k, --keep-folders    Keep templates organized in folders by repo name
   -p, --path string     Root path to save the templates (default "cent-nuclei-templates")
   -t, --threads int     Number of threads to use when cloning repositories (default 10)
+  -T, --timeout int     Timeout in minutes for each git clone (default 2)
 ```
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ By xm1k3`,
 		console, _ := cmd.Flags().GetBool("console")
 		threads, _ := cmd.Flags().GetInt("threads")
 		timeout, _ := cmd.Flags().GetInt("timeout")
+		keepFolders, _ := cmd.Flags().GetBool("keep-folders")
 
 		configDir, err := utils.GetDataDir()
 		if err != nil {
@@ -74,11 +75,13 @@ By xm1k3`,
 
 		fmt.Println(color.CyanString("cent started"))
 
-		jobs.Start(pathFlag, console, threads, timeout)
+		jobs.Start(pathFlag, console, threads, timeout, keepFolders)
 		jobs.RemoveEmptyFolders(path.Join(pathFlag))
 		jobs.UpdateRepo(path.Join(pathFlag), true, true, false)
-		jobs.RemoveDuplicates(path.Join(pathFlag), console)
-		fmt.Println(color.YellowString("[!] Removed duplicates"))
+		if !keepFolders {
+			jobs.RemoveDuplicates(path.Join(pathFlag), console)
+			fmt.Println(color.YellowString("[!] Removed duplicates"))
+		}
 		fmt.Println(color.CyanString("cent finished, you can find all your nuclei-templates in " + pathFlag))
 	},
 }
@@ -100,6 +103,7 @@ func init() {
 	rootCmd.Flags().BoolP("console", "C", false, "Print console output")
 	rootCmd.Flags().IntP("threads", "t", 10, "Number of threads to use when cloning repositories")
 	rootCmd.Flags().IntP("timeout", "T", 2, "timeout in seconds")
+	rootCmd.Flags().BoolP("keep-folders", "k", false, "Keep templates organized in folders by repo name")
 
 	rootCmd.MarkFlagRequired("name")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,7 +102,7 @@ func init() {
 	rootCmd.Flags().StringP("path", "p", "cent-nuclei-templates", "Root path to save the templates")
 	rootCmd.Flags().BoolP("console", "C", false, "Print console output")
 	rootCmd.Flags().IntP("threads", "t", 10, "Number of threads to use when cloning repositories")
-	rootCmd.Flags().IntP("timeout", "T", 2, "timeout in seconds")
+	rootCmd.Flags().IntP("timeout", "T", 2, "timeout in minutes for each git clone")
 	rootCmd.Flags().BoolP("keep-folders", "k", false, "Keep templates organized in folders by repo name")
 
 	rootCmd.MarkFlagRequired("name")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -18,8 +18,8 @@ import (
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate templates",
-	Long: `The validate command is a part of the application's functionality to validate templates. 
-When executed, it scans a specified folder for YAML files. Each YAML file is checked for validity. 
+	Long: `The validate command is a part of the application's functionality to validate templates.
+When executed, it scans a specified folder for YAML files. Each YAML file is checked for validity.
 If a template is found to be invalid, it is deleted from the folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		path, _ := cmd.Flags().GetString("path")
@@ -35,17 +35,9 @@ If a template is found to be invalid, it is deleted from the folder.`,
 				go func(filePath string) {
 					defer wg.Done()
 
-					data, err := readFile(filePath)
-					if err != nil {
-						return
-					}
-
-					isValid, err := jobs.ValidateTemplate(data)
+					err := jobs.ValidateTemplateFile(filePath)
 					if err != nil {
 						fmt.Println(filePath, err)
-					}
-
-					if !isValid {
 						os.Remove(filePath)
 					}
 				}(filePath)
@@ -55,14 +47,6 @@ If a template is found to be invalid, it is deleted from the folder.`,
 
 		wg.Wait()
 	},
-}
-
-func readFile(filePath string) (string, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
 }
 
 func init() {

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -21,14 +21,14 @@ import (
 	"github.com/xm1k3/cent/v2/internal/utils"
 )
 
-func cloneRepo(gitPath string, console bool, index string, timestamp string) error {
+func cloneRepo(gitPath string, console bool, index string, timestamp string, timeoutMinutes int) error {
 	destDir := filepath.Join(os.TempDir(), fmt.Sprintf("cent%s/repo%s", timestamp, index))
 
 	if err := os.MkdirAll(destDir, 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	timeout := 60 * time.Second
+	timeout := time.Duration(timeoutMinutes) * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -53,10 +53,10 @@ func cloneRepo(gitPath string, console bool, index string, timestamp string) err
 	return nil
 }
 
-func worker(work chan [2]string, wg *sync.WaitGroup, console bool, timestamp string, defaultTimeout int) {
+func worker(work chan [2]string, wg *sync.WaitGroup, console bool, timestamp string, timeoutMinutes int) {
 	defer wg.Done()
 	for repo := range work {
-		err := cloneRepo(repo[1], console, repo[0], timestamp)
+		err := cloneRepo(repo[1], console, repo[0], timestamp, timeoutMinutes)
 		if err != nil {
 			fmt.Println(color.RedString("[ERR] clone: " + repo[1] + " - " + err.Error()))
 		}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -63,7 +63,20 @@ func worker(work chan [2]string, wg *sync.WaitGroup, console bool, timestamp str
 	}
 }
 
-func Start(_path string, console bool, threads int, defaultTimeout int) {
+func repoNameFromURL(url string) string {
+	url = strings.TrimSuffix(url, ".git")
+	url = strings.TrimSuffix(url, "/")
+	parts := strings.Split(url, "/")
+	if len(parts) >= 2 {
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return url
+}
+
+func Start(_path string, console bool, threads int, defaultTimeout int, keepFolders bool) {
 	timestamp := strconv.Itoa(int(time.Now().Unix()))
 	if _, err := os.Stat(filepath.Join(_path)); os.IsNotExist(err) {
 		os.Mkdir(filepath.Join(_path), 0700)
@@ -73,9 +86,15 @@ func Start(_path string, console bool, threads int, defaultTimeout int) {
 		log.Fatalf("Git is not installed or not available in PATH: %v", err)
 	}
 
+	templates := viper.GetStringSlice("community-templates")
+	repoNames := make(map[string]string)
+	for index, gitPath := range templates {
+		repoNames[strconv.Itoa(index)] = repoNameFromURL(gitPath)
+	}
+
 	work := make(chan [2]string)
 	go func() {
-		for index, gitPath := range viper.GetStringSlice("community-templates") {
+		for index, gitPath := range templates {
 			work <- [2]string{strconv.Itoa(index), gitPath}
 		}
 		close(work)
@@ -96,20 +115,28 @@ func Start(_path string, console bool, threads int, defaultTimeout int) {
 			return err
 		}
 
-		directory := getDirPath(strings.TrimPrefix(path, dirname))
-
 		if info.IsDir() {
-		} else {
-			basename := info.Name()
-			if filepath.Ext(basename) == ".yaml" {
-				directory = ""
-				sourcePath := path
-				destinationPath := filepath.Join(_path, directory, basename)
+			return nil
+		}
 
-				err := utils.CopyFile(sourcePath, destinationPath)
-				if err != nil {
-					return err
-				}
+		basename := info.Name()
+		if filepath.Ext(basename) == ".yaml" {
+			var destinationPath string
+			if keepFolders {
+				relPath := strings.TrimPrefix(path, dirname+string(os.PathSeparator))
+				parts := strings.SplitN(relPath, string(os.PathSeparator), 2)
+				repoDir := parts[0]
+				idx := strings.TrimPrefix(repoDir, "repo")
+				repoName := repoNames[idx]
+				destinationPath = filepath.Join(_path, repoName, basename)
+				os.MkdirAll(filepath.Dir(destinationPath), 0700)
+			} else {
+				destinationPath = filepath.Join(_path, basename)
+			}
+
+			err := utils.CopyFile(path, destinationPath)
+			if err != nil {
+				return err
 			}
 		}
 

--- a/pkg/jobs/validate_local.go
+++ b/pkg/jobs/validate_local.go
@@ -1,0 +1,157 @@
+package jobs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	ReTemplateID = regexp.MustCompile(`^([a-zA-Z0-9]+[-_])*[a-zA-Z0-9]+$`)
+)
+
+type StringOrSlice []string
+
+func (s *StringOrSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		*s = []string{single}
+	} else {
+		*s = multi
+	}
+	return nil
+}
+
+type Info struct {
+	Name     string        `yaml:"name" json:"name"`
+	Author   StringOrSlice `yaml:"author" json:"author"`
+	Severity string        `yaml:"severity" json:"severity"`
+}
+
+type TemplateValidation struct {
+	ID         string                 `yaml:"id" json:"id"`
+	Info       Info                   `yaml:"info" json:"info"`
+	Requests   []interface{}          `yaml:"requests,omitempty" json:"requests,omitempty"`
+	HTTP       []interface{}          `yaml:"http,omitempty" json:"http,omitempty"`
+	DNS        []interface{}          `yaml:"dns,omitempty" json:"dns,omitempty"`
+	File       []interface{}          `yaml:"file,omitempty" json:"file,omitempty"`
+	Network    []interface{}          `yaml:"network,omitempty" json:"network,omitempty"`
+	TCP        []interface{}          `yaml:"tcp,omitempty" json:"tcp,omitempty"`
+	Headless   []interface{}          `yaml:"headless,omitempty" json:"headless,omitempty"`
+	SSL        []interface{}          `yaml:"ssl,omitempty" json:"ssl,omitempty"`
+	Websocket  []interface{}          `yaml:"websocket,omitempty" json:"websocket,omitempty"`
+	WHOIS      []interface{}          `yaml:"whois,omitempty" json:"whois,omitempty"`
+	Code       []interface{}          `yaml:"code,omitempty" json:"code,omitempty"`
+	Javascript []interface{}          `yaml:"javascript,omitempty" json:"javascript,omitempty"`
+	Workflows  []interface{}          `yaml:"workflows,omitempty" json:"workflows,omitempty"`
+	Flow       string                 `yaml:"flow,omitempty" json:"flow,omitempty"`
+	Variables  map[string]interface{} `yaml:"variables,omitempty" json:"variables,omitempty"`
+	Constants  map[string]interface{} `yaml:"constants,omitempty" json:"constants,omitempty"`
+}
+
+func isBlank(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, c := range s {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return false
+		}
+	}
+	return true
+}
+
+func validateTemplateMandatoryFields(template *TemplateValidation) error {
+	info := template.Info
+
+	var validateErrors []error
+
+	if isBlank(info.Name) {
+		validateErrors = append(validateErrors, fmt.Errorf("mandatory 'name' field is missing"))
+	}
+
+	if len(info.Author) == 0 {
+		validateErrors = append(validateErrors, fmt.Errorf("mandatory 'author' field is missing"))
+	}
+
+	if template.ID == "" {
+		validateErrors = append(validateErrors, fmt.Errorf("mandatory 'id' field is missing"))
+	} else if !ReTemplateID.MatchString(template.ID) {
+		validateErrors = append(validateErrors, fmt.Errorf("invalid field format for 'id' (allowed format is %s)", ReTemplateID.String()))
+	}
+
+	if len(validateErrors) > 0 {
+		return errors.Join(validateErrors...)
+	}
+
+	return nil
+}
+
+func validateTemplateOptionalFields(template *TemplateValidation) error {
+	info := template.Info
+
+	var warnings []error
+
+	hasProtocol := len(template.Workflows) > 0 ||
+		len(template.Requests) > 0 ||
+		len(template.HTTP) > 0 ||
+		len(template.DNS) > 0 ||
+		len(template.File) > 0 ||
+		len(template.Network) > 0 ||
+		len(template.TCP) > 0 ||
+		len(template.Headless) > 0 ||
+		len(template.SSL) > 0 ||
+		len(template.Websocket) > 0 ||
+		len(template.WHOIS) > 0 ||
+		len(template.Code) > 0 ||
+		len(template.Javascript) > 0
+
+	if hasProtocol && len(template.Workflows) == 0 && isBlank(info.Severity) {
+		warnings = append(warnings, fmt.Errorf("field 'severity' is missing"))
+	}
+
+	if len(warnings) > 0 {
+		return errors.Join(warnings...)
+	}
+
+	return nil
+}
+
+func ValidateTemplateFile(templatePath string) error {
+	file, err := os.Open(templatePath)
+	if err != nil {
+		return fmt.Errorf("could not open template file: %w", err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("could not read template file: %w", err)
+	}
+
+	template := &TemplateValidation{}
+	err = yaml.Unmarshal(data, template)
+	if err != nil {
+		return fmt.Errorf("could not parse template: %w", err)
+	}
+
+	if err := validateTemplateMandatoryFields(template); err != nil {
+		return fmt.Errorf("mandatory field validation failed: %w", err)
+	}
+
+	if err := validateTemplateOptionalFields(template); err != nil {
+		fmt.Printf("[WARN] %s: %v\n", templatePath, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Add `--keep-folders` / `-k` flag to organize templates by repo folder (#74)
- Local template validation instead of external API
- Treat optional validation fields as warnings instead of errors
- Fix timeout flag not being passed to git clone (#81, #84)