### PR TITLE
Extended config, pinned commit, per-repo exclude, --by-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Community edition nuclei templates, a simple tool that allows you to organize al
 <a href="https://twitter.com/xm1k3_"><img src="https://img.shields.io/twitter/follow/xm1k3_.svg?logo=twitter"></a>
 <br>
 <br>
-<br>
-<a href="https://www.buymeacoffee.com/xm1k3"><img src="https://www.buymeacoffee.com/assets/img/custom_images/purple_img.png"></a>
 </p>
 
 # Install
@@ -43,8 +41,9 @@ after installation run `cent init` to initialize cent with the configuration fil
 ```
 Flags:
       --config string   config file (default is .config/cent/.cent.yaml)
+  -r, --by-repo         Group templates by repository (use with -k)
   -C, --console         Print console output
-  -k, --keep-folders    Keep templates organized in folders by repo name
+  -k, --keep-folders    Keep templates organized in folders by category
   -p, --path string     Root path to save the templates (default "cent-nuclei-templates")
   -t, --threads int     Number of threads to use when cloning repositories (default 10)
   -T, --timeout int     Timeout in minutes for each git clone (default 2)
@@ -88,20 +87,39 @@ cent started
 cent finished, you can find all your nuclei-templates in cent-nuclei-templates
 ```
 
-### Keep templates organized by repo
-Use the `-k` flag to keep templates in separate folders named after the source repository:
+### Keep templates organized by category
+Use the `-k` flag to keep the internal folder structure of each repository:
 ```
 cent -p cent-nuclei-templates -k
 ```
 This will create a folder structure like:
 ```
 cent-nuclei-templates/
+  cves/
+    CVE-2021-1234.yaml
+  vulnerabilities/
+    template.yaml
+  others/
+    uncategorized-template.yaml
+```
+
+Templates without a subfolder in their source repo are placed in `others/`.
+
+### Group templates by repository
+Use `-k -r` to also group templates by their source repository:
+```
+cent -p cent-nuclei-templates -k -r
+```
+```
+cent-nuclei-templates/
   projectdiscovery/nuclei-templates/
-    cve-2021-1234.yaml
-    ...
+    cves/
+      CVE-2021-1234.yaml
+    vulnerabilities/
+      template.yaml
   user/repo-name/
-    custom-template.yaml
-    ...
+    others/
+      custom-template.yaml
 ```
 
 ## Summary Command
@@ -275,13 +293,23 @@ exclude-files:
   - .pre-commit-config.yaml
   - LICENSE
 
-# Add github urls
+# Add github urls (simple format)
 community-templates:
   - https://github.com/projectdiscovery/nuclei-templates
-  ...
-  ...
+  - https://github.com/other/repo
 
+  # Extended format: pin a repo to a specific commit
+  - url: https://github.com/user/repo
+    commit: abc123f
+
+  # Extended format: per-repo exclude
+  - url: https://github.com/user/repo2
+    exclude:
+      - "workflows/"
+      - "fuzzing/"
 ```
+
+Both formats can be mixed in the same config file. When `commit` is specified, cent will clone the full repo and checkout that specific commit instead of using a shallow clone. Per-repo `exclude` filters out matching paths from that specific repository.
 
 ## Credits
 - [hakluke](https://twitter.com/hakluke)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ By xm1k3`,
 		threads, _ := cmd.Flags().GetInt("threads")
 		timeout, _ := cmd.Flags().GetInt("timeout")
 		keepFolders, _ := cmd.Flags().GetBool("keep-folders")
+		byRepo, _ := cmd.Flags().GetBool("by-repo")
 
 		configDir, err := utils.GetDataDir()
 		if err != nil {
@@ -75,7 +76,7 @@ By xm1k3`,
 
 		fmt.Println(color.CyanString("cent started"))
 
-		jobs.Start(pathFlag, console, threads, timeout, keepFolders)
+		jobs.Start(pathFlag, console, threads, timeout, keepFolders, byRepo)
 		jobs.RemoveEmptyFolders(path.Join(pathFlag))
 		jobs.UpdateRepo(path.Join(pathFlag), true, true, false)
 		if !keepFolders {
@@ -103,7 +104,8 @@ func init() {
 	rootCmd.Flags().BoolP("console", "C", false, "Print console output")
 	rootCmd.Flags().IntP("threads", "t", 10, "Number of threads to use when cloning repositories")
 	rootCmd.Flags().IntP("timeout", "T", 2, "timeout in minutes for each git clone")
-	rootCmd.Flags().BoolP("keep-folders", "k", false, "Keep templates organized in folders by repo name")
+	rootCmd.Flags().BoolP("keep-folders", "k", false, "Keep templates organized in folders by category")
+	rootCmd.Flags().BoolP("by-repo", "r", false, "Group templates by repository (use with -k)")
 
 	rootCmd.MarkFlagRequired("name")
 }

--- a/pkg/jobs/check.go
+++ b/pkg/jobs/check.go
@@ -8,14 +8,27 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
-	"github.com/xm1k3/cent/v2/internal/utils"
 	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
-	ExcludeDirs        []string `yaml:"exclude-dirs"`
-	ExcludeFiles       []string `yaml:"exclude-files"`
-	CommunityTemplates []string `yaml:"community-templates"`
+	ExcludeDirs        []string    `yaml:"exclude-dirs"`
+	ExcludeFiles       []string    `yaml:"exclude-files"`
+	CommunityTemplates []yaml.Node `yaml:"community-templates"`
+}
+
+func configEntryURL(node yaml.Node) string {
+	if node.Kind == yaml.ScalarNode {
+		return node.Value
+	}
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			if node.Content[i].Value == "url" {
+				return node.Content[i+1].Value
+			}
+		}
+	}
+	return ""
 }
 
 func CheckConfig(configPath string, removeFlag bool) error {
@@ -32,7 +45,12 @@ func CheckConfig(configPath string, removeFlag bool) error {
 
 	var wg sync.WaitGroup
 
-	for _, url := range config.CommunityTemplates {
+	for _, node := range config.CommunityTemplates {
+		url := configEntryURL(node)
+		if url == "" {
+			continue
+		}
+
 		if removeFlag && strings.Contains(url, "gist.github.com") {
 			fmt.Println(color.YellowString("[INFO] Ignoring and removing gist.github.com URL: %s", url))
 			RemoveURLFromConfig(configPath, url)
@@ -81,10 +99,17 @@ func RemoveURLFromConfig(configPath, url string) error {
 		return err
 	}
 
+	var filtered []yaml.Node
+	for _, node := range config.CommunityTemplates {
+		if configEntryURL(node) != url {
+			filtered = append(filtered, node)
+		}
+	}
+
 	updatedConfig := Config{
 		ExcludeDirs:        config.ExcludeDirs,
 		ExcludeFiles:       config.ExcludeFiles,
-		CommunityTemplates: utils.RemoveStringFromSlice(config.CommunityTemplates, url),
+		CommunityTemplates: filtered,
 	}
 
 	updatedYAML, err := yaml.Marshal(&updatedConfig)

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -21,7 +21,46 @@ import (
 	"github.com/xm1k3/cent/v2/internal/utils"
 )
 
-func cloneRepo(gitPath string, console bool, index string, timestamp string, timeoutMinutes int) error {
+type RepoEntry struct {
+	URL     string   `yaml:"url"`
+	Commit  string   `yaml:"commit,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
+}
+
+func ParseRepoEntries() []RepoEntry {
+	raw := viper.Get("community-templates")
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var entries []RepoEntry
+	for _, item := range items {
+		switch v := item.(type) {
+		case string:
+			entries = append(entries, RepoEntry{URL: v})
+		case map[string]interface{}:
+			entry := RepoEntry{}
+			if u, ok := v["url"].(string); ok {
+				entry.URL = u
+			}
+			if c, ok := v["commit"].(string); ok {
+				entry.Commit = c
+			}
+			if e, ok := v["exclude"].([]interface{}); ok {
+				for _, ex := range e {
+					if s, ok := ex.(string); ok {
+						entry.Exclude = append(entry.Exclude, s)
+					}
+				}
+			}
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func cloneRepo(entry RepoEntry, console bool, index string, timestamp string, timeoutMinutes int) error {
 	destDir := filepath.Join(os.TempDir(), fmt.Sprintf("cent%s/repo%s", timestamp, index))
 
 	if err := os.MkdirAll(destDir, 0700); err != nil {
@@ -32,7 +71,13 @@ func cloneRepo(gitPath string, console bool, index string, timestamp string, tim
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--single-branch", "--no-tags", "--no-recurse-submodules", gitPath, destDir)
+	cloneArgs := []string{"clone", "--single-branch", "--no-tags", "--no-recurse-submodules"}
+	if entry.Commit == "" {
+		cloneArgs = append(cloneArgs, "--depth", "1")
+	}
+	cloneArgs = append(cloneArgs, entry.URL, destDir)
+
+	cmd := exec.CommandContext(ctx, "git", cloneArgs...)
 
 	if console {
 		cmd.Stdout = os.Stdout
@@ -43,22 +88,39 @@ func cloneRepo(gitPath string, console bool, index string, timestamp string, tim
 
 	err := cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("git clone timed out for %s", gitPath)
+		return fmt.Errorf("git clone timed out for %s", entry.URL)
 	}
 	if err != nil {
-		return fmt.Errorf("git clone failed for %s: %w", gitPath, err)
+		return fmt.Errorf("git clone failed for %s: %w", entry.URL, err)
 	}
 
-	fmt.Printf(color.GreenString("[CLONED] %s\n", gitPath))
+	if entry.Commit != "" {
+		cmdCheckout := exec.CommandContext(ctx, "git", "-C", destDir, "checkout", entry.Commit)
+		if console {
+			cmdCheckout.Stdout = os.Stdout
+			cmdCheckout.Stderr = os.Stderr
+		}
+		if err := cmdCheckout.Run(); err != nil {
+			return fmt.Errorf("git checkout %s failed for %s: %w", entry.Commit, entry.URL, err)
+		}
+		fmt.Printf(color.GreenString("[CLONED] %s @ %s\n", entry.URL, entry.Commit))
+	} else {
+		fmt.Printf(color.GreenString("[CLONED] %s\n", entry.URL))
+	}
 	return nil
 }
 
-func worker(work chan [2]string, wg *sync.WaitGroup, console bool, timestamp string, timeoutMinutes int) {
+type repoWork struct {
+	index string
+	entry RepoEntry
+}
+
+func worker(work chan repoWork, wg *sync.WaitGroup, console bool, timestamp string, timeoutMinutes int) {
 	defer wg.Done()
 	for repo := range work {
-		err := cloneRepo(repo[1], console, repo[0], timestamp, timeoutMinutes)
+		err := cloneRepo(repo.entry, console, repo.index, timestamp, timeoutMinutes)
 		if err != nil {
-			fmt.Println(color.RedString("[ERR] clone: " + repo[1] + " - " + err.Error()))
+			fmt.Println(color.RedString("[ERR] clone: " + repo.entry.URL + " - " + err.Error()))
 		}
 	}
 }
@@ -76,7 +138,7 @@ func repoNameFromURL(url string) string {
 	return url
 }
 
-func Start(_path string, console bool, threads int, defaultTimeout int, keepFolders bool) {
+func Start(_path string, console bool, threads int, defaultTimeout int, keepFolders bool, byRepo bool) {
 	timestamp := strconv.Itoa(int(time.Now().Unix()))
 	if _, err := os.Stat(filepath.Join(_path)); os.IsNotExist(err) {
 		os.Mkdir(filepath.Join(_path), 0700)
@@ -86,16 +148,21 @@ func Start(_path string, console bool, threads int, defaultTimeout int, keepFold
 		log.Fatalf("Git is not installed or not available in PATH: %v", err)
 	}
 
-	templates := viper.GetStringSlice("community-templates")
+	entries := ParseRepoEntries()
 	repoNames := make(map[string]string)
-	for index, gitPath := range templates {
-		repoNames[strconv.Itoa(index)] = repoNameFromURL(gitPath)
+	repoExcludes := make(map[string][]string)
+	for index, entry := range entries {
+		idx := strconv.Itoa(index)
+		repoNames[idx] = repoNameFromURL(entry.URL)
+		if len(entry.Exclude) > 0 {
+			repoExcludes[idx] = entry.Exclude
+		}
 	}
 
-	work := make(chan [2]string)
+	work := make(chan repoWork)
 	go func() {
-		for index, gitPath := range templates {
-			work <- [2]string{strconv.Itoa(index), gitPath}
+		for index, entry := range entries {
+			work <- repoWork{index: strconv.Itoa(index), entry: entry}
 		}
 		close(work)
 	}()
@@ -119,25 +186,44 @@ func Start(_path string, console bool, threads int, defaultTimeout int, keepFold
 			return nil
 		}
 
-		basename := info.Name()
-		if filepath.Ext(basename) == ".yaml" {
-			var destinationPath string
-			if keepFolders {
-				relPath := strings.TrimPrefix(path, dirname+string(os.PathSeparator))
-				parts := strings.SplitN(relPath, string(os.PathSeparator), 2)
-				repoDir := parts[0]
-				idx := strings.TrimPrefix(repoDir, "repo")
-				repoName := repoNames[idx]
-				destinationPath = filepath.Join(_path, repoName, basename)
-				os.MkdirAll(filepath.Dir(destinationPath), 0700)
-			} else {
-				destinationPath = filepath.Join(_path, basename)
-			}
+		relPath := strings.TrimPrefix(path, dirname+string(os.PathSeparator))
+		parts := strings.SplitN(relPath, string(os.PathSeparator), 2)
+		repoDir := parts[0]
+		idx := strings.TrimPrefix(repoDir, "repo")
 
-			err := utils.CopyFile(path, destinationPath)
-			if err != nil {
-				return err
+		if excludes, ok := repoExcludes[idx]; ok {
+			for _, ex := range excludes {
+				if strings.Contains(relPath, ex) {
+					return nil
+				}
 			}
+		}
+
+		if filepath.Ext(info.Name()) != ".yaml" {
+			return nil
+		}
+
+		var destinationPath string
+		if keepFolders {
+			innerPath := ""
+			if len(parts) > 1 {
+				innerPath = parts[1]
+			}
+			if !strings.Contains(innerPath, string(os.PathSeparator)) {
+				innerPath = filepath.Join("others", innerPath)
+			}
+			if byRepo {
+				repoName := repoNames[idx]
+				innerPath = filepath.Join(repoName, innerPath)
+			}
+			destinationPath = filepath.Join(_path, innerPath)
+			os.MkdirAll(filepath.Dir(destinationPath), 0700)
+		} else {
+			destinationPath = filepath.Join(_path, info.Name())
+		}
+
+		if cpErr := utils.CopyFile(path, destinationPath); cpErr != nil {
+			return cpErr
 		}
 
 		return nil


### PR DESCRIPTION
- Extended config format: support both simple URLs and objects with `url`, `commit`, `exclude`
- Pinned commit: clone a repo at a specific commit (#86)
- Per-repo exclude: filter paths per repository in config
- `--by-repo` / `-r` flag: group templates by source repo (use with `-k`)
- `--keep-folders` now preserves internal category structure, uncategorized templates go to `others/`